### PR TITLE
 Update site URLs in metadata

### DIFF
--- a/src/app/layout.jsx
+++ b/src/app/layout.jsx
@@ -101,12 +101,12 @@ export const metadata = {
       "Dislexia y Conducta | Innovación tecnológica aplicada al aprendizaje",
     description:
       "Dislexia y Conducta ofrece evaluaciones, diagnósticos y tratamientos basados en neurociencia para niños, adolescentes y adultos.",
-    url: "https://dislexiayconducta.vercel.app/",
+    url: "https://dislexiayconducta.com/",
     siteName: "Dislexia y Conducta",
     locale: "es_AR",
     images: [
       {
-        url: "https://dislexiayconducta.vercel.app/banner.png",
+        url: "https://dislexiayconducta.com/banner.png",
         width: 1200,
         height: 630,
         alt: "Dislexia y Conducta | Evaluación y Tratamientos",


### PR DESCRIPTION
## refactor(landing): 🔗 Update site URLs in metadata

Changed the metadata URLs and image links from the Vercel deployment domain to the official dislexiayconducta.com domain for consistency and production readiness.