### PR TITLE
Update team section layout and CTA links

### DIFF
--- a/src/components/shared/navbar/Navbar.jsx
+++ b/src/components/shared/navbar/Navbar.jsx
@@ -1,7 +1,6 @@
 "use client";
 import { Link as LinkScroll } from "react-scroll";
 import { Button } from "../../ui/button";
-import Image from "next/image";
 import { Menu } from "lucide-react";
 import { useState, useEffect } from "react";
 import { useLenis } from "@/lib/useLenis";
@@ -40,18 +39,9 @@ export function Navbar() {
             <LinkScroll
               to="inicio"
               smooth
-              className="text-neutral-b0 font-medium text-2xl cursor-pointer flex items-center gap-2"
+              className="text-neutral-b0 font-bold text-2xl cursor-pointer flex items-center gap-2"
             >
-              Dislexia&Conducta{" "}
-              <Image
-                src="/logo.svg"
-                alt="logo DislexiaConducta"
-                title="logo DislexiaConducta"
-                width={24}
-                height={24}
-                loading="eager"
-                priority
-              />
+              Dislexia&Conducta             
             </LinkScroll>
           </div>
 

--- a/src/components/ui/layout-grid.jsx
+++ b/src/components/ui/layout-grid.jsx
@@ -35,8 +35,8 @@ export const LayoutGrid = ({ cards }) => {
               selected?.id === card.id
                 ? `rounded-none absolute inset-0 m-auto z-50 flex justify-center items-center flex-wrap flex-col ${
                     card.orientation === "horizontal"
-                      ? "lg:w-full h-1/3 lg:h-1/2"
-                      : "lg:w-1/3 h-1/2 lg:h-1/2"
+                      ? "lg:w-1/2 h-1/2 lg:h-1/2"
+                      : "lg:w-1/3 h-full lg:h-1/2"
                   }`
                 : lastSelected?.id === card.id
                 ? "z-40 bg-white rounded-none h-full w-full"

--- a/src/features/cta/CTA.jsx
+++ b/src/features/cta/CTA.jsx
@@ -55,18 +55,6 @@ const CTA = () => {
           </Link>
 
           <Link
-            href="https://tally.so/r/n098j6"
-            title="Test Ansiedad"
-            target="_blank"
-            className="group"
-          >
-            <Button variant="secondary" className="w-full sm:max-w-max">
-              Ansiedad
-              <ArrowUpRight size={24} />
-            </Button>
-          </Link>
-
-          <Link
             href="https://tally.so/r/wLrK4p"
             title="Test Discalculia"
             target="_blank"
@@ -74,6 +62,18 @@ const CTA = () => {
           >
             <Button variant="secondary" className="w-full sm:max-w-max">
               Discalculia
+              <ArrowUpRight size={24} />
+            </Button>
+          </Link>
+
+          <Link
+            href="https://tally.so/r/n098j6"
+            title="Test Ansiedad"
+            target="_blank"
+            className="group"
+          >
+            <Button variant="secondary" className="w-full sm:max-w-max">
+              Ansiedad
               <ArrowUpRight size={24} />
             </Button>
           </Link>

--- a/src/features/team/Team.jsx
+++ b/src/features/team/Team.jsx
@@ -152,19 +152,12 @@ const teamCardsLarge = [
   {
     id: 2,
     content: <AbstractPattern />,
-    className: "col-span-1 h-[175px] lg:h-[440px]", // Primera fila, segunda columna - más baja
+    className: "col-span-2 h-[175px] lg:h-[460px]", // Primera fila, segunda columna - más baja
     thumbnail: "/videos/team/deco-1.mp4",
     orientation: "vertical",
   },
   {
     id: 3,
-    content: <BeachScene />,
-    className: "col-span-1 h-[175px] lg:h-[420px]", // Primera fila, tercera columna - altura media
-    thumbnail: "/videos/team/deco-2.mp4",
-    orientation: "vertical",
-  },
-  {
-    id: 4,
     content: <TeamMemberTwo />,
     className: "col-span-1 h-[175px] lg:h-[460px]", // Primera fila, cuarta columna - más alta
     thumbnail: "/imgs/team/Lic.Maria-Lourdes-Mazzola-Vernengo.webp",
@@ -174,44 +167,16 @@ const teamCardsLarge = [
     orientation: "vertical",
   },
   {
-    id: 5,
-    content: <TeamMemberThree />,
-    className: "col-span-1 h-[175px] lg:h-[340px]", // Segunda fila, primera columna - más baja
-    thumbnail: "/imgs/team/team-5.webp",
-    orientation: "vertical",
-  },
-  {
-    id: 6,
-    content: <TeamMemberFour />,
-    className: "col-span-1 h-[175px] lg:h-[280px] lg:-top-[20px]", // Segunda fila, segunda columna - altura media
-    thumbnail: "/imgs/team/team-2.webp",
-    orientation: "vertical",
-  },
-  {
-    id: 7,
-    content: <TeamMemberFive />,
-    className: "col-span-1 h-[175px] lg:h-[300px] lg:-top-[40px]", // Segunda fila, tercera columna - más baja
-    thumbnail: "/imgs/team/team-3.webp",
-    orientation: "vertical",
-  },
-  {
-    id: 8,
-    content: <TeamMemberSix />,
-    className: "col-span-1 h-[175px] lg:h-[340px]", // Segunda fila, cuarta columna - más alta
-    thumbnail: "/imgs/team/team-4.webp",
-    orientation: "vertical",
-  },
-  {
-    id: 9,
+    id: 4,
     content: <AbstractPattern />,
-    className: "col-span-1 h-[175px] lg:h-[260px]", // Tercera fila, primera columna - más baja
+    className: "col-span-1 h-[175px] lg:h-[370px]", // Tercera fila, primera columna - más baja
     thumbnail: "/videos/team/deco-3.mp4",
     orientation: "vertical",
   },
   {
-    id: 10,
+    id: 5,
     content: <TeamGroup />,
-    className: "col-span-2 h-[175px] lg:h-[340px] lg:-top-[80px]", // Tercera fila, segunda y tercera columna - más alta y ancha
+    className: "col-span-2 h-[175px] lg:h-[370px]", // Tercera fila, segunda y tercera columna - más alta y ancha
     thumbnail: "/imgs/team/team-full.webp",
     orientation: "horizontal",
     title: "Team Dislexia y Conducta",
@@ -219,10 +184,10 @@ const teamCardsLarge = [
       "Lic. Sol Barrionuevo, Lic. Candela Rodríguez, Lic. Lourdes Mazzola, Lic. Marcela Alegre, Lola Martene Devoto, María Luz Fernández y  Lic. María Sol Bayugar.",
   },
   {
-    id: 11,
-    content: <TeamMemberSeven />,
-    className: "col-span-1 h-[175px] lg:h-[260px]", // Tercera fila, cuarta columna - altura media
-    thumbnail: "/imgs/team/team-1.webp",
+    id: 6,
+    content: <BeachScene />,
+    className: "col-span-1 h-[175px] lg:h-[370px]", // Primera fila, tercera columna - altura media
+    thumbnail: "/videos/team/deco-2.mp4",
     orientation: "vertical",
   },
 ];
@@ -259,62 +224,27 @@ const teamCardsSmall = [
   },
   {
     id: 4,
-    content: <BeachScene />, // Cambiado: ahora es BeachScene
-    className: "col-span-1 h-[150px] lg:h-[460px]", // Primera fila, cuarta columna - más alta
-    thumbnail: "/videos/team/deco-2.mp4", // Cambiado: thumbnail de BeachScene
-    orientation: "vertical",
-  },
-  {
-    id: 5,
-    content: <TeamMemberThree />,
-    className: "col-span-1 h-[150px] lg:h-[320px]", // Segunda fila, primera columna - más baja
-    thumbnail: "/imgs/team/team-5.webp",
-    orientation: "vertical",
-  },
-  {
-    id: 6,
-    content: <TeamMemberSix />,
-    className: "col-span-1 h-[150px] lg:h-[300px] lg:-top-[30px]", // Segunda fila, segunda columna - altura media
-    thumbnail: "/imgs/team/team-4.webp",
-    orientation: "vertical",
-  },
-  {
-    id: 7,
-    content: <TeamMemberFive />,
-    className: "col-span-1 h-[130px] lg:h-[320px] lg:-top-[60px]", // Segunda fila, tercera columna - más baja
-    thumbnail: "/imgs/team/team-3.webp",
-    orientation: "vertical",
-  },
-  {
-    id: 8,
-    content: <TeamMemberFour />,
-    className: "col-span-1 h-[130px] lg:h-[320px]", // Segunda fila, cuarta columna - más alta
-    thumbnail: "/imgs/team/team-2.webp",
-    orientation: "vertical",
-  },
-  {
-    id: 9,
-    content: <TeamMemberSeven />,
-    className: "col-span-1 h-[130px] lg:h-[180px]", // Tercera fila, primera columna - más baja
-    thumbnail: "/imgs/team/team-1.webp",
-    orientation: "vertical",
-  },
-  {
-    id: 10,
-    content: <AbstractPattern />,
-    className: "col-span-3 h-[175px] lg:h-[240px]", // Tercera fila, cuarta columna - altura media
-    thumbnail: "/videos/team/deco-3.mp4",
-    orientation: "vertical",
-  },
-  {
-    id: 11,
     content: <TeamGroup />,
-    className: "col-span-3 h-[175px] sm:h-[320px] lg:h-[320px] lg:-top-[80px]", // 1 fila en small, 2 filas en md+
+    className: "col-span-3 h-[175px] sm:h-[320px] lg:h-[320px]", // 1 fila en small, 2 filas en md+
     thumbnail: "/imgs/team/team-full.webp",
     orientation: "horizontal",
     title: "Team Dislexia y Conducta",
     description:
       "Lic. Sol Barrionuevo, Lic. Candela Rodríguez, Lic. Lourdes Mazzola, Lic. Marcela Alegre, Lola Martene Devoto, María Luz Fernández y  Lic. María Sol Bayugar.",
+  },
+  {
+    id: 5,
+    content: <BeachScene />, // Cambiado: ahora es BeachScene
+    className: "col-span-2 h-[175px] lg:h-[460px]", // Primera fila, cuarta columna - más alta
+    thumbnail: "/videos/team/deco-3.mp4", // Cambiado: thumbnail de BeachScene
+    orientation: "vertical",
+  },
+  {
+    id: 6,
+    content: <AbstractPattern />,
+    className: "col-span-1 h-[175px] lg:h-[240px]", // Tercera fila, cuarta columna - altura media
+    thumbnail: "/videos/team/deco-2.mp4",
+    orientation: "vertical",
   },
 ];
 


### PR DESCRIPTION
## refactor(landing): 🎨Update team section layout and CTA links
Refactored the team section card layout for both large and small screens, adjusting card order, sizes, and content. Updated CTA buttons to swap links and labels for 'Ansiedad' and 'Discalculia' tests. Improved navbar branding by removing the logo image and making the brand name bold. Adjusted layout grid card sizing for better visual balance. Updated team video asset.